### PR TITLE
Fix ansible-lint test failures and release tarball upload auth

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -41,6 +41,7 @@ mock_modules:
   - ansible.controller.job_launch
   - ansible.controller.job_template
   - ansible.controller.job_cancel
+  - ansible.controller.job_wait
   - ansible.controller.label
   - ansible.controller.notification_template
   - ansible.controller.organization
@@ -100,10 +101,33 @@ mock_modules:
   - ansible.hub.ah_token
   - ansible.hub.ah_approval
 
-# mock_roles:
-#   - mocked_role
-#   - author.role_name # old standalone galaxy role
-#   - fake_namespace.fake_collection.fake_role # role within a collection
+mock_roles:
+  - infra.aap_configuration.ansible_config
+  - infra.aap_configuration.dispatch
+  - infra.aap_configuration.eda_controller_tokens
+  - infra.aap_configuration.eda_credential_input_sources
+  - infra.aap_configuration.eda_credential_types
+  - infra.aap_configuration.eda_credentials
+  - infra.aap_configuration.eda_decision_environments
+  - infra.aap_configuration.eda_event_streams
+  - infra.aap_configuration.eda_projects
+  - infra.aap_configuration.eda_rulebook_activations
+  - infra.aap_configuration.eda_users
+  - infra.aap_configuration.hub_collection
+  - infra.aap_configuration.hub_collection_remote
+  - infra.aap_configuration.hub_collection_repository
+  - infra.aap_configuration.hub_ee_image
+  - infra.aap_configuration.hub_ee_registry
+  - infra.aap_configuration.hub_ee_registry_index
+  - infra.aap_configuration.hub_ee_registry_sync
+  - infra.aap_configuration.hub_ee_repository
+  - infra.aap_configuration.hub_ee_repository_sync
+  - infra.aap_configuration.hub_group
+  - infra.aap_configuration.hub_group_roles
+  - infra.aap_configuration.hub_namespace
+  - infra.aap_configuration.hub_publish
+  - infra.aap_configuration.hub_role
+  - infra.aap_configuration.hub_user
 
 # Enable checking of loop variable prefixes in roles
 loop_var_prefix: "^(__|{role}_)"

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,7 +15,6 @@ exclude_paths:
   - changelogs/
   - tests/templated_role_example
   - .ansible/
-  - tests/
 
 # quiet: true
 # strict: true

--- a/.github/workflows/release_auto.yml
+++ b/.github/workflows/release_auto.yml
@@ -284,10 +284,16 @@ jobs:
 
       - name: Upload tarball and publish release
         env:
-          GH_TOKEN: ${{ secrets.GH_WORKFLOW_KEY }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.calculate_version.outputs.collection_version }}
         run: |
-          for tarball in ${{ env.COLLECTION_NAMESPACE }}-${{ env.COLLECTION_NAME }}*.tar.gz; do
+          shopt -s nullglob
+          tarballs=(${{ env.COLLECTION_NAMESPACE }}-${{ env.COLLECTION_NAME }}*.tar.gz)
+          if [ ${#tarballs[@]} -eq 0 ]; then
+            echo "::error::No collection tarball found to upload"
+            exit 1
+          fi
+          for tarball in "${tarballs[@]}"; do
             ASSET_NAME=$(basename "$tarball")
             EXISTING=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq ".assets[].name" 2>/dev/null || true)
             if echo "$EXISTING" | grep -qF "$ASSET_NAME"; then

--- a/changelogs/fragments/fix-lint-and-release-upload.yml
+++ b/changelogs/fragments/fix-lint-and-release-upload.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - Fix ansible-lint failures in test playbooks and role test files by adding YAML document end markers and simplifying controller_api lookup plugin detection.
+  - Fix ansible-lint failures in test playbooks and role test files by adding YAML document end markers, simplifying controller_api lookup plugin detection, and configuring ansible-lint mock modules/roles for job_wait and collection role references.
   - Fix release tarball upload by using the workflow GITHUB_TOKEN instead of the expired GH_WORKFLOW_KEY secret.
 ...

--- a/changelogs/fragments/fix-lint-and-release-upload.yml
+++ b/changelogs/fragments/fix-lint-and-release-upload.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Fix ansible-lint failures in test playbooks and role test files by adding YAML document end markers and simplifying controller_api lookup plugin detection.
+  - Fix release tarball upload by using the workflow GITHUB_TOKEN instead of the expired GH_WORKFLOW_KEY secret.
+...

--- a/roles/controller_bulk_host_create/tests/configs/bulk_hosts.yml
+++ b/roles/controller_bulk_host_create/tests/configs/bulk_hosts.yml
@@ -12,3 +12,4 @@ controller_bulk_hosts:
     description: "Test host 3"
     inventory: "Demo Inventory"
     variables: "ansible_host: 192.168.1.12"
+...

--- a/roles/controller_bulk_host_create/tests/test.yml
+++ b/roles/controller_bulk_host_create/tests/test.yml
@@ -17,3 +17,4 @@
 
   roles:
     - { role: ../.., when: controller_bulk_hosts is defined }
+...

--- a/roles/controller_bulk_job_launch/tests/configs/bulk_jobs.yml
+++ b/roles/controller_bulk_job_launch/tests/configs/bulk_jobs.yml
@@ -5,3 +5,4 @@ controller_bulk_launch_jobs:
     limit: "webservers"
   - name: "demo-workflow-job-template"
     job_type: "run"
+...

--- a/roles/controller_bulk_job_launch/tests/test.yml
+++ b/roles/controller_bulk_job_launch/tests/test.yml
@@ -17,3 +17,4 @@
 
   roles:
     - { role: ../.., when: controller_bulk_launch_jobs is defined }
+...

--- a/roles/controller_workflow_job_templates/tests/test.yml
+++ b/roles/controller_workflow_job_templates/tests/test.yml
@@ -17,3 +17,4 @@
 
   roles:
     - { role: ../.., when: controller_workflows is defined }
+...

--- a/tests/configure_controller.yml
+++ b/tests/configure_controller.yml
@@ -23,10 +23,22 @@
             awx_awx_collection_installed: "{{ lookup('ansible.builtin.pipe', 'ansible-galaxy collection list | grep -i awx.awx || echo NOTINSTALLED') }}"
           failed_when: awx_awx_collection_installed is match('NOTINSTALLED')
       always:
-        - name: Set the collection providing the controller_api lookup plugin
+        - name: Set the collection providing the controller_api lookup plugin from ansible.controller
           ansible.builtin.set_fact:
-            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api'
-              if awx_awx_collection_installed is defined) | default('NONE') }}"
+            controller_api_plugin: ansible.controller.controller_api
+          when: ansible_controller_collection_installed is defined
+
+        - name: Set the collection providing the controller_api lookup plugin from awx.awx
+          ansible.builtin.set_fact:
+            controller_api_plugin: awx.awx.controller_api
+          when:
+            - controller_api_plugin is not defined
+            - awx_awx_collection_installed is defined
+
+        - name: Set the collection providing the controller_api lookup plugin to none
+          ansible.builtin.set_fact:
+            controller_api_plugin: NONE
+          when: controller_api_plugin is not defined
         - name: Fail if no collection is detected
           ansible.builtin.fail:
             msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."

--- a/tests/configure_controller_export_model.yml
+++ b/tests/configure_controller_export_model.yml
@@ -22,10 +22,22 @@
             awx_awx_collection_installed: "{{ lookup('ansible.builtin.pipe', 'ansible-galaxy collection list | grep -i awx.awx || echo NOTINSTALLED') }}"
           failed_when: awx_awx_collection_installed is match('NOTINSTALLED')
       always:
-        - name: Set the collection providing the controller_api lookup plugin
+        - name: Set the collection providing the controller_api lookup plugin from ansible.controller
           ansible.builtin.set_fact:
-            controller_api_plugin: "{{ ('ansible.controller.controller_api' if ansible_controller_collection_installed is defined) | default('awx.awx.controller_api'
-              if awx_awx_collection_installed is defined) | default('NONE') }}"
+            controller_api_plugin: ansible.controller.controller_api
+          when: ansible_controller_collection_installed is defined
+
+        - name: Set the collection providing the controller_api lookup plugin from awx.awx
+          ansible.builtin.set_fact:
+            controller_api_plugin: awx.awx.controller_api
+          when:
+            - controller_api_plugin is not defined
+            - awx_awx_collection_installed is defined
+
+        - name: Set the collection providing the controller_api lookup plugin to none
+          ansible.builtin.set_fact:
+            controller_api_plugin: NONE
+          when: controller_api_plugin is not defined
         - name: Fail if no collection is detected
           ansible.builtin.fail:
             msg: "One of the following collections is required to be installed: 'ansible.controller' or 'awx.awx'."


### PR DESCRIPTION
## Summary
- Enable linting of the `tests/` directory and fix the resulting ansible-lint failures in test playbooks and role test files (YAML document end markers and controller API lookup plugin detection).
- Fix the release workflow tarball upload job, which failed on the Aug 18 scheduled release with `401 Unauthorized` because it used the expired `GH_WORKFLOW_KEY` secret instead of the workflow `GITHUB_TOKEN`.

## Test plan
- [x] `ansible-lint` passes on the updated test playbooks and role test files
- [x] Pre-commit hooks pass locally (ansible-lint, changelog, galaxy-importer)
- [ ] Verify the next release run uploads the collection tarball to the GitHub release successfully


Made with [Cursor](https://cursor.com)