### PR TITLE
[DOCS] credential_type is a required field on a credential

### DIFF
--- a/changelogs/fragments/docs-credential-type-is-required.yml
+++ b/changelogs/fragments/docs-credential-type-is-required.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Correcting the documentation for the controller_credentials role to indicate that credential_type is a required field."

--- a/roles/controller_credentials/README.md
+++ b/roles/controller_credentials/README.md
@@ -79,7 +79,7 @@ This also speeds up the overall role.
 |`copy_from`|""|no|Name or id to copy the credential from. This will copy an existing credential and change any parameters supplied.|
 |`description`|`false`|no|Description of  of Credential.|
 |`organization`|""|no|Organization this Credential belongs to. If provided on creation, do not give either user or team.|
-|`credential_type`|""|no|Name of credential type. See below for list of options. More information in Ansible controller documentation.|
+|`credential_type`|""|yes|Name of credential type. See below for list of options. More information in Ansible controller documentation.|
 |`inputs`|""|no|Credential inputs where the keys are var names used in templating. Refer to the Ansible controller documentation for example syntax. Individual examples can be found at /api/controller/v2/credential_types/ on an controller.|
 |`user`|""|no|User that should own this credential. If provided, do not give either team or organization.|
 |`team`|""|no|Team that should own this credential. If provided, do not give either user or organization.|

--- a/roles/controller_credentials/meta/argument_specs.yml
+++ b/roles/controller_credentials/meta/argument_specs.yml
@@ -30,7 +30,7 @@ argument_specs:
 #            description: Organization this Credential belongs to. If provided on creation, do not give either user or team.
 #          credential_type:
 #            type: str
-#            required: false
+#            required: true
 #            description: Name of credential type. See below for list of options. More information in Ansible controller documentation.
 #          inputs:
 #            type: dict


### PR DESCRIPTION
# What does this PR do?

This PR updates the documentation for controller_credential role so that credential_type is accurately reflected as being required. 

## How should this be tested?

This is a documentation change. A review is sufficient to ensure that no code changes are made and that the documentation is accurate.

## Is there a relevant Issue open for this?

No.

## Other Relevant info, PRs, etc

Line in the awx collection indicating that credential_type is required: [https://github.com/ansible/awx/blob/d6675e67e057c659b2e664c4b5de8b4b15a7042d/awx_collection/plugins/modules/credential.py#L220](https://github.com/ansible/awx/blob/d6675e67e057c659b2e664c4b5de8b4b15a7042d/awx_collection/plugins/modules/credential.py#L220).