### PR TITLE
Skip existing collection versions in hub_publish

### DIFF
--- a/changelogs/fragments/1412-skip-existing-hub-collections.yml
+++ b/changelogs/fragments/1412-skip-existing-hub-collections.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - hub_publish - Skip clone, build, and upload when a collection version already exists in Automation Hub. Use hub_overwrite_existing or per-item force to re-publish. Optional namespace, name, and collection_version fields enable pre-clone skip checks. Set hub_skip_existing_collections to false to restore the previous always-build behavior.
+...

--- a/roles/hub_publish/README.md
+++ b/roles/hub_publish/README.md
@@ -21,6 +21,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`aap_configuration_working_dir`|`/var/tmp`|no|The working directory where the built artifacts live, or where the artifacts will be built.||
 |`hub_auto_approve`|`false`|no|Whether the collection will be automatically approved in Automation Hub. This will only work if the account being used has correct privileges.||
 |`hub_overwrite_existing`|`false`|no|Whether the collection will be automatically overwrite an existing collection in Automation Hub. This will only work if the account being used has correct privileges.||
+|`hub_skip_existing_collections`|`true`|no|Skip clone, build, and upload when the collection version already exists in Automation Hub. Set `hub_overwrite_existing` to `true` to force re-publishing. Set to `false` to restore the previous always-build behavior.||
 |`hub_repository`|`staging`|no|Name of the destination repository to publish collections to. Defaults to `staging`.||
 |`hub_custom_collections`|`see below`|no|Data structure describing your collections, mutually exclusive to hub_collection_list, described below.||
 |`hub_collection_list`|`list`|no|Data structure file paths to pre built collections, mutually exclusive with hub_custom_collections.||
@@ -67,7 +68,23 @@ This also speeds up the overall role.
 |`key_path`|""|no|str|Path to ssh key for authentication.|
 |`ssh_opts`|""|no|str|Options git will pass to ssh when used as protocol.|
 |`collection_local_path`|""|no|str|Path to collection stored locally. Required if git_url not set. This value will be used rather than git_url if set.|
+|`namespace`|""|no|str|Collection namespace. When combined with `name` and `collection_version`, enables a pre-clone Hub check to skip git checkout on re-runs.|
+|`name`|""|no|str|Collection name. When combined with `namespace` and `collection_version`, enables a pre-clone Hub check to skip git checkout on re-runs.|
+|`collection_version`|""|no|str|Collection version from `galaxy.yml`. Distinct from the git `version` ref. Enables pre-clone skip checks when set with `namespace` and `name`.|
+|`overwrite_existing`|`false`|no|bool|Per-item override of `hub_overwrite_existing`.|
+|`force`|`false`|no|bool|Alias for per-item `overwrite_existing: true`.|
 |`register`|""|no|str|Variable to set based on the result of the object creation/modification|
+
+The same per-item fields also apply to dictionary entries in `hub_collection_list` when publishing from a local source path.
+
+### Skip Existing Collections
+
+When `hub_skip_existing_collections` is `true` (default), the role queries Automation Hub for each collection version before cloning, building, or uploading. If the version already exists, those steps are skipped for that item.
+
+- The existence check uses the global collection version API endpoint, matching `ansible.hub.ah_collection` behavior. It does not verify repository membership in `hub_repository`.
+- Provide `namespace`, `name`, and `collection_version` on an item to enable a pre-clone skip check without reading `galaxy.yml`.
+- Set `hub_skip_existing_collections: false` to always clone and build, matching pre-4.7 behavior.
+- Per-item `overwrite_existing` or `force` disables the skip check for that item and passes the overwrite flag through to upload.
 
 ### Standard Project Data Structure
 
@@ -76,10 +93,15 @@ This also speeds up the overall role.
 ```yaml
 ---
 hub_custom_collections:
-  - collection_name: cisco.iosxr
-    git_url: https://github.com/ansible-collections/cisco.iosxr
+  - collection_name: ansible.utils
+    git_url: https://github.com/ansible-collections/ansible.utils
+    namespace: ansible
+    name: utils
+    collection_version: "4.1.0"
+    version: "v4.1.0"
 
 hub_auto_approve: true
+hub_skip_existing_collections: true
 ```
 
 ## Playbook Examples

--- a/roles/hub_publish/defaults/main.yml
+++ b/roles/hub_publish/defaults/main.yml
@@ -21,6 +21,7 @@ aap_configuration_working_dir: /var/tmp
 
 hub_auto_approve: "{{ ah_auto_approve | default(false) }}"
 hub_overwrite_existing: "{{ ah_overwrite_existing | default(false) }}"
+hub_skip_existing_collections: "{{ ah_skip_existing_collections | default(true) }}"
 hub_repository: "{{ ah_repository | default('staging') }}"
 
 hub_configuration_publish_secure_logging: "{{ aap_configuration_secure_logging | default(false) }}"

--- a/roles/hub_publish/meta/argument_specs.yml
+++ b/roles/hub_publish/meta/argument_specs.yml
@@ -18,12 +18,62 @@ argument_specs:
         type: bool
         required: false
         description: Whether the collection will be automatically overwrite an existing collection in Automation Hub. This will only work if the account being used has correct privileges.
+      hub_skip_existing_collections:
+        default: true
+        type: bool
+        required: false
+        description: Skip clone, build, and upload when the collection version already exists in Automation Hub. Set hub_overwrite_existing to true to force re-publishing.
       hub_collections:
         default: []
         required: false
         description: Data structure describing your collections, mutually exclusive to hub_collection_list
         type: list
         elements: dict
+        options:
+          collection_name:
+            type: str
+            required: true
+            description: Name of collection, normally the last part before the / in a git url.
+          git_url:
+            type: str
+            required: false
+            description: Url to git repo. Required if collection_local_path not set.
+          version:
+            type: str
+            required: false
+            description: Git ref to pull. Will default to default branch if unset.
+          key_path:
+            type: str
+            required: false
+            description: Path to ssh key for authentication.
+          ssh_opts:
+            type: str
+            required: false
+            description: Options git will pass to ssh when used as protocol.
+          collection_local_path:
+            type: str
+            required: false
+            description: Path to collection stored locally. Required if git_url not set.
+          namespace:
+            type: str
+            required: false
+            description: Collection namespace. Enables pre-clone skip checks when set with name and collection_version.
+          name:
+            type: str
+            required: false
+            description: Collection name. Enables pre-clone skip checks when set with namespace and collection_version.
+          collection_version:
+            type: str
+            required: false
+            description: Collection version from galaxy.yml. Enables pre-clone skip checks when set with namespace and name.
+          overwrite_existing:
+            type: bool
+            required: false
+            description: Per-item override of hub_overwrite_existing.
+          force:
+            type: bool
+            required: false
+            description: Alias for per-item overwrite_existing true.
       hub_collection_list:
         default: []
         required: false

--- a/roles/hub_publish/tasks/check_collection_version.yml
+++ b/roles/hub_publish/tasks/check_collection_version.yml
@@ -3,7 +3,7 @@
 # This checks whether the collection version exists globally, not repository membership in hub_repository.
 - name: check_collection_version | Query collection version in Hub
   ansible.builtin.uri:
-    url: "{{ aap_hostname.rstrip('/') }}/api/{{ hub_path_prefix | default(ah_path_prefix | default('galaxy')) }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
+    url: "https://{{ aap_hostname | regex_replace('^https?://', '') | rstrip('/') }}/api/{{ hub_path_prefix | default(ah_path_prefix | default('galaxy')) }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"
     force_basic_auth: "{{ (aap_username is defined and aap_password is defined and hub_token is not defined) | bool }}"

--- a/roles/hub_publish/tasks/check_collection_version.yml
+++ b/roles/hub_publish/tasks/check_collection_version.yml
@@ -3,7 +3,7 @@
 # This checks whether the collection version exists globally, not repository membership in hub_repository.
 - name: check_collection_version | Query collection version in Hub
   ansible.builtin.uri:
-    url: "https://{{ aap_hostname | regex_replace('^https?://', '') | rstrip('/') }}/api/{{ hub_path_prefix | default(ah_path_prefix | default('galaxy')) }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
+    url: "https://{{ (aap_hostname | regex_replace('^https?://', '')).rstrip('/') }}/api/{{ hub_path_prefix | default(ah_path_prefix | default('galaxy')) }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
     user: "{{ aap_username | default(omit) }}"
     password: "{{ aap_password | default(omit) }}"
     force_basic_auth: "{{ (aap_username is defined and aap_password is defined and hub_token is not defined) | bool }}"

--- a/roles/hub_publish/tasks/check_collection_version.yml
+++ b/roles/hub_publish/tasks/check_collection_version.yml
@@ -1,0 +1,26 @@
+---
+# ah_collection cannot query version existence without a path, so use the Hub API directly.
+# This checks whether the collection version exists globally, not repository membership in hub_repository.
+- name: check_collection_version | Query collection version in Hub
+  ansible.builtin.uri:
+    url: "{{ aap_hostname.rstrip('/') }}/api/{{ hub_path_prefix | default(ah_path_prefix | default('galaxy')) }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
+    user: "{{ aap_username | default(omit) }}"
+    password: "{{ aap_password | default(omit) }}"
+    force_basic_auth: "{{ (aap_username is defined and aap_password is defined and hub_token is not defined) | bool }}"
+    headers: "{{ {'Authorization': 'Token ' + hub_token} if hub_token is defined else omit }}"
+    validate_certs: "{{ aap_validate_certs | default(true) }}"
+    timeout: "{{ aap_request_timeout | default(10) }}"
+    status_code: [200, 404]
+  register: __hub_publish_version_lookup
+
+- name: check_collection_version | Determine whether to skip publishing this collection version
+  ansible.builtin.set_fact:
+    __hub_publish_should_skip: "{{ hub_skip_existing_collections | bool and (__hub_publish_version_lookup.status == 200) and not __hub_publish_overwrite | bool }}"
+
+- name: check_collection_version | Skip collection already present in Automation Hub
+  ansible.builtin.debug:
+    msg: "Skipping {{ __hub_publish_namespace }}.{{ __hub_publish_name }}:{{ __hub_publish_version }} — already present in Automation Hub"
+    verbosity: 1
+  when: __hub_publish_should_skip | bool
+
+...

--- a/roles/hub_publish/tasks/evaluate_custom_collection_item.yml
+++ b/roles/hub_publish/tasks/evaluate_custom_collection_item.yml
@@ -1,0 +1,81 @@
+---
+- name: evaluate_custom_collection_item | Set per-item overwrite flag
+  ansible.builtin.set_fact:
+    __hub_publish_overwrite: "{{ __hub_collection_item.overwrite_existing | default(__hub_collection_item.force | default(hub_overwrite_existing)) | bool }}"
+    __hub_publish_has_early_metadata: "{{ (__hub_collection_item.namespace | default('') | length > 0) and (__hub_collection_item.name | default('') | length > 0) and (__hub_collection_item.collection_version | default('') | length > 0) }}"
+    __hub_publish_should_skip: false
+
+- name: evaluate_custom_collection_item | Set collection metadata from item fields
+  ansible.builtin.set_fact:
+    __hub_publish_namespace: "{{ __hub_collection_item.namespace }}"
+    __hub_publish_name: "{{ __hub_collection_item.name }}"
+    __hub_publish_version: "{{ __hub_collection_item.collection_version }}"
+  when: __hub_publish_has_early_metadata | bool
+
+- name: evaluate_custom_collection_item | Early existence check with upfront metadata
+  ansible.builtin.include_tasks: check_collection_version.yml
+  when:
+    - __hub_publish_has_early_metadata | bool
+    - hub_skip_existing_collections | bool
+
+- name: evaluate_custom_collection_item | Git checkout
+  ansible.builtin.git:
+    repo: "{{ __hub_collection_item.git_url }}"
+    dest: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
+    version: "{{ __hub_collection_item.version | default(omit) }}"
+    key_file: "{{ __hub_collection_item.key_path | default(omit) }}"
+    ssh_opts: "{{ __hub_collection_item.ssh_opts | default(omit) }}"
+  when:
+    - not (__hub_publish_should_skip | default(false) | bool)
+    - __hub_collection_item.git_url is defined
+    - __hub_collection_item.collection_local_path is not defined
+
+- name: evaluate_custom_collection_item | Copy local collection to working dir
+  ansible.builtin.copy:
+    src: "{{ __hub_collection_item.collection_local_path }}/"
+    dest: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
+    remote_src: true
+    mode: "0700"
+  when:
+    - not (__hub_publish_should_skip | default(false) | bool)
+    - __hub_collection_item.collection_local_path is defined
+
+- name: evaluate_custom_collection_item | Read collection galaxy.yml
+  ansible.builtin.slurp:
+    src: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}/galaxy.yml"
+  register: __hub_publish_galaxy_yml
+  when:
+    - not (__hub_publish_should_skip | default(false) | bool)
+    - not (__hub_publish_has_early_metadata | bool)
+
+- name: evaluate_custom_collection_item | Parse collection metadata from galaxy.yml
+  ansible.builtin.set_fact:
+    __hub_publish_namespace: "{{ (__hub_publish_galaxy_yml.content | b64decode | from_yaml).namespace }}"
+    __hub_publish_name: "{{ (__hub_publish_galaxy_yml.content | b64decode | from_yaml).name }}"
+    __hub_publish_version: "{{ (__hub_publish_galaxy_yml.content | b64decode | from_yaml).version }}"
+  when:
+    - not (__hub_publish_should_skip | default(false) | bool)
+    - not (__hub_publish_has_early_metadata | bool)
+
+- name: evaluate_custom_collection_item | Existence check after reading collection metadata
+  ansible.builtin.include_tasks: check_collection_version.yml
+  when:
+    - not (__hub_publish_should_skip | default(false) | bool)
+    - not (__hub_publish_has_early_metadata | bool)
+    - hub_skip_existing_collections | bool
+
+- name: evaluate_custom_collection_item | Cleanup working dir for skipped collection
+  ansible.builtin.file:
+    path: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
+    state: absent
+  when:
+    - __hub_publish_should_skip | default(false) | bool
+    - not (__hub_publish_has_early_metadata | bool)
+
+- name: evaluate_custom_collection_item | Register pending collection item
+  ansible.builtin.set_fact:
+    __hub_publish_pending_items: "{{ __hub_publish_pending_items + [__hub_collection_item] }}"
+    __hub_publish_overwrite_lookup: "{{ __hub_publish_overwrite_lookup | combine({(__hub_publish_namespace + '.' + __hub_publish_name + ':' + __hub_publish_version): __hub_publish_overwrite}) }}"
+  when: not (__hub_publish_should_skip | default(false) | bool)
+
+...

--- a/roles/hub_publish/tasks/evaluate_tarball_item.yml
+++ b/roles/hub_publish/tasks/evaluate_tarball_item.yml
@@ -1,0 +1,20 @@
+---
+- name: evaluate_tarball_item | Set tarball metadata from filename
+  ansible.builtin.set_fact:
+    __hub_publish_namespace: "{{ (__hub_collection_tarball | basename).split('-')[0] }}"
+    __hub_publish_name: "{{ (__hub_collection_tarball | basename).split('-')[1] }}"
+    __hub_publish_version: "{{ (__hub_collection_tarball | basename).split('-')[2:] | join('-') | splitext | first | splitext | first }}"
+    __hub_publish_overwrite: "{{ hub_overwrite_existing | bool }}"
+    __hub_publish_should_skip: false
+
+- name: evaluate_tarball_item | Existence check for pre-built collection tarball
+  ansible.builtin.include_tasks: check_collection_version.yml
+  when: hub_skip_existing_collections | bool
+
+- name: evaluate_tarball_item | Register pending pre-built collection tarball
+  ansible.builtin.set_fact:
+    __hub_publish_pending_tarballs: "{{ __hub_publish_pending_tarballs + [__hub_collection_tarball] }}"
+    __hub_publish_overwrite_lookup: "{{ __hub_publish_overwrite_lookup | combine({(__hub_publish_namespace + '.' + __hub_publish_name + ':' + __hub_publish_version): __hub_publish_overwrite}) }}"
+  when: not (__hub_publish_should_skip | default(false) | bool)
+
+...

--- a/roles/hub_publish/tasks/main.yml
+++ b/roles/hub_publish/tasks/main.yml
@@ -4,35 +4,39 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ hub_configuration_publish_secure_logging }}"
   block:
-    - name: Git checkout
-      ansible.builtin.git:
-        repo: "{{ __hub_collection_item.git_url }}"
-        dest: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
-        version: "{{ __hub_collection_item.version | default(omit) }}"
-        key_file: "{{ __hub_collection_item.key_path | default(omit) }}"
-        ssh_opts: "{{ __hub_collection_item.ssh_opts | default(omit) }}"
+    - name: Initialize publish item lists
+      ansible.builtin.set_fact:
+        __hub_publish_pending_items: []
+        __hub_publish_pending_tarballs: []
+        __hub_publish_overwrite_lookup: {}
+        __hub_collection_list: []
+
+    - name: Evaluate custom collections for skip
+      ansible.builtin.include_tasks: evaluate_custom_collection_item.yml
       loop: "{{ hub_custom_collections }}"
       loop_control:
         loop_var: __hub_collection_item
-        label: "{{ __hub_collection_item.git_url }}"
+        label: "{{ __hub_collection_item.collection_name }}"
         pause: "{{ hub_configuration_publish_loop_delay }}"
-      when:
-        - hub_collection_list | length == 0
-        - __hub_collection_item.collection_local_path is not defined
+      when: hub_collection_list | length == 0
 
-    - name: Copy local collection to working dir
-      ansible.builtin.copy:
-        src: "{{ __hub_collection_item.collection_local_path }}/"
-        dest: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
-        remote_src: true
-        mode: "0700"
-      loop: "{{ hub_collection_list }}"
+    - name: Evaluate hub_collection_list local collections for skip
+      ansible.builtin.include_tasks: evaluate_custom_collection_item.yml
+      loop: "{{ hub_collection_list | reject('string') | list }}"
       loop_control:
         loop_var: __hub_collection_item
-        label: "{{ __hub_collection_item.collection_local_path }}"
-      when:
-        - hub_collection_list | length > 0
-        - __hub_collection_item.collection_local_path is defined
+        label: "{{ __hub_collection_item.collection_name }}"
+        pause: "{{ hub_configuration_publish_loop_delay }}"
+      when: hub_collection_list | length > 0
+
+    - name: Evaluate pre-built collection tarballs for skip
+      ansible.builtin.include_tasks: evaluate_tarball_item.yml
+      loop: "{{ hub_collection_list | select('string') | list }}"
+      loop_control:
+        loop_var: __hub_collection_tarball
+        label: "{{ __hub_collection_tarball | basename }}"
+        pause: "{{ hub_configuration_publish_loop_delay }}"
+      when: hub_collection_list | length > 0
 
     - name: Build Collections
       ansible.hub.ah_build:
@@ -40,36 +44,52 @@
         output_path: "{{ aap_configuration_working_dir }}/{{ __hub_collection_item.collection_name }}"
         force: true
       register: __hub_build_results
-      loop: "{{ hub_collection_list | default(hub_custom_collections, true) | select }}"
+      loop: "{{ __hub_publish_pending_items }}"
       loop_control:
         loop_var: __hub_collection_item
         label: "{{ __hub_collection_item.collection_name }}"
+        pause: "{{ hub_configuration_publish_loop_delay }}"
+      when: __hub_publish_pending_items | length > 0
 
     - name: Find if variable contains file or dir
       ansible.builtin.stat:
         path: "{{ __hub_build_result_item.path }}"
       register: __hub_build_stat_results
-      loop: "{{ __hub_build_results.results }}"
+      loop: "{{ __hub_build_results.results | default([]) }}"
       loop_control:
         loop_var: __hub_build_result_item
         label: "{{ __hub_build_result_item.path }}"
-      when: __hub_build_results is not skipped
+      when:
+        - __hub_build_results is defined
+        - __hub_build_results is not skipped
 
     - name: Find all relevant built collection files
       ansible.builtin.find:
         paths: "{{ (__hub_build_result_item.stat.isdir) | ternary(__hub_build_result_item.stat.path, (__hub_build_result_item.stat.path | dirname)) }}"
         patterns: "{{ (__hub_build_result_item.stat.isdir) | ternary('*.tar.gz', (__hub_build_result_item.stat.path | basename)) }}"
       register: __hub_collections_find_results
-      loop: "{{ __hub_build_stat_results.results }}"
+      loop: "{{ __hub_build_stat_results.results | default([]) }}"
       loop_control:
         loop_var: __hub_build_result_item
         label: "{{ __hub_build_result_item.stat.path }}"
-      when: __hub_build_results is not skipped
+      when:
+        - __hub_build_results is defined
+        - __hub_build_results is not skipped
 
     - name: Set path for all collections found
       ansible.builtin.set_fact:
-        __hub_collection_list: "{{ __hub_collections_find_results.results | map(attribute='files') | flatten | map(attribute='path') | flatten }}"
-      when: __hub_build_results is not skipped
+        __hub_collection_list: "{{ (__hub_publish_pending_tarballs | default([])) + (__hub_collections_find_results.results | default([]) | map(attribute='files') | flatten | map(attribute='path') | list) }}"
+      when:
+        - __hub_build_results is defined
+        - __hub_build_results is not skipped or (__hub_publish_pending_tarballs | default([]) | length > 0)
+
+    - name: Set path for pending pre-built collection tarballs only
+      ansible.builtin.set_fact:
+        __hub_collection_list: "{{ __hub_publish_pending_tarballs }}"
+      when:
+        - hub_collection_list | length > 0
+        - __hub_publish_pending_tarballs | length > 0
+        - __hub_build_results is skipped
 
     - name: Get token
       ansible.hub.ah_token:
@@ -83,16 +103,22 @@
         - hub_token is not defined
         - lookup("ansible.builtin.env", "AH_API_TOKEN") | length > 0
         - __hub_collection_list is defined
+        - __hub_collection_list | length > 0
 
     - name: Publish Collections
+      vars:
+        __hub_publish_file_namespace: "{{ (__hub_collection_file | basename).split('-')[0] }}"
+        __hub_publish_file_name: "{{ (__hub_collection_file | basename).split('-')[1] }}"
+        __hub_publish_file_version: "{{ (__hub_collection_file | basename).split('-')[2:] | join('-') | splitext | first | splitext | first }}"
+        __hub_publish_file_key: "{{ __hub_publish_file_namespace + '.' + __hub_publish_file_name + ':' + __hub_publish_file_version }}"
       ansible.hub.ah_collection:
-        namespace: "{{ (__hub_collection_file | basename).split('-')[0] }}"
-        name: "{{ (__hub_collection_file | basename).split('-')[1] }}"
-        version: "{{ (__hub_collection_file | basename).split('-')[2:] | join('-') | splitext | first | splitext | first }}"
+        namespace: "{{ __hub_publish_file_namespace }}"
+        name: "{{ __hub_publish_file_name }}"
+        version: "{{ __hub_publish_file_version }}"
         path: "{{ __hub_collection_file }}"
         repository: "{{ hub_repository }}"
         auto_approve: "{{ hub_auto_approve }}"
-        overwrite_existing: "{{ hub_overwrite_existing }}"
+        overwrite_existing: "{{ __hub_publish_overwrite_lookup[__hub_publish_file_key] | default(hub_overwrite_existing) | bool }}"
         ah_host: "{{ aap_hostname | default(omit) }}"
         ah_username: "{{ aap_username | default(omit) }}"
         ah_password: "{{ aap_password | default(omit) }}"
@@ -103,11 +129,14 @@
       loop: "{{ __hub_collection_list }}"
       loop_control:
         loop_var: __hub_collection_file
+        pause: "{{ hub_configuration_publish_loop_delay }}"
       async: "{{ hub_configuration_publish_async_timeout }}"
       poll: 0
       register: __publish_job_async
       changed_when: false
-      when: __hub_collection_list is defined
+      when:
+        - __hub_collection_list is defined
+        - __hub_collection_list | length > 0
 
     - name: Publish Collection | Wait for finish the publish creation
       when:
@@ -115,7 +144,7 @@
         - __publish_job_async_result_item.ansible_job_id is defined
       ansible.builtin.include_role:
         name: infra.aap_configuration.collect_async_status
-      loop: "{{ __publish_job_async.results }}"
+      loop: "{{ __publish_job_async.results | default([]) }}"
       loop_control:
         loop_var: __publish_job_async_result_item
       vars:
@@ -139,12 +168,14 @@
         ah_path_prefix: "{{ hub_path_prefix | default(ah_path_prefix | default(omit)) }}"
         validate_certs: "{{ aap_validate_certs | default(omit) }}"
         request_timeout: "{{ aap_request_timeout | default(omit) }}"
-      loop: "{{ __hub_collection_list }}"
+      loop: "{{ __hub_collection_list | default([]) }}"
       loop_control:
         loop_var: __hub_collection_file
+        pause: "{{ hub_configuration_publish_loop_delay }}"
       when:
         - not hub_auto_approve
         - __hub_collection_list is defined
+        - __hub_collection_list | length > 0
       register: approval
       retries: 3
       delay: 2
@@ -154,11 +185,13 @@
       ansible.builtin.file:
         path: "{{ __hub_collection_item | dirname }}"
         state: absent
-      loop: "{{ __hub_collection_list }}"
+      loop: "{{ __hub_collection_list | default([]) }}"
       loop_control:
         loop_var: __hub_collection_item
         label: "{{ __hub_collection_item | dirname }}"
-      when: __hub_collection_list is defined
+      when:
+        - __hub_collection_list is defined
+        - __hub_collection_list | length > 0
 
   always:
     - name: Cleanup async results files
@@ -168,7 +201,7 @@
       ansible.builtin.async_status:
         jid: "{{ __publish_job_async_result_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __publish_job_async.results }}"
+      loop: "{{ __publish_job_async.results | default([]) }}"
       loop_control:
         loop_var: __publish_job_async_result_item
         label: "Cleaning up job results file: {{ __publish_job_async_result_item.results_file | default('Unknown') }}"

--- a/roles/hub_publish/tests/check_hostname_url_test.yml
+++ b/roles/hub_publish/tests/check_hostname_url_test.yml
@@ -1,0 +1,41 @@
+---
+- name: Test hub_publish hostname URL normalization
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    __hub_publish_namespace: infra
+    __hub_publish_name: aap_configuration
+    __hub_publish_version: "4.7.0"
+    __hub_publish_hostname_url_cases:
+      - hostname: aap.example.com
+        expected_host: aap.example.com
+      - hostname: https://aap.example.com
+        expected_host: aap.example.com
+      - hostname: https://aap.example.com/
+        expected_host: aap.example.com
+      - hostname: http://aap.example.com
+        expected_host: aap.example.com
+      - hostname: aap.example.com/
+        expected_host: aap.example.com
+      - hostname: https://hub.example.com
+        hub_path_prefix: automation-hub
+        expected_host: hub.example.com
+        expected_path_prefix: automation-hub
+  tasks:
+    - name: Validate hub_publish version check URL for each hostname format
+      ansible.builtin.assert:
+        that:
+          - __hub_publish_version_check_url == __hub_publish_expected_url
+        fail_msg: >-
+          hostname '{{ item.hostname }}' produced '{{ __hub_publish_version_check_url }}',
+          expected '{{ __hub_publish_expected_url }}'
+      vars:
+        __hub_publish_path_prefix: "{{ item.hub_path_prefix | default(hub_path_prefix | default(ah_path_prefix | default('galaxy'))) }}"
+        __hub_publish_version_check_url: "https://{{ (item.hostname | regex_replace('^https?://', '')).rstrip('/') }}/api/{{ __hub_publish_path_prefix }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
+        __hub_publish_expected_url: "https://{{ item.expected_host }}/api/{{ item.expected_path_prefix | default('galaxy') }}/v3/collections/{{ __hub_publish_namespace }}/{{ __hub_publish_name }}/versions/{{ __hub_publish_version }}/"
+      loop: "{{ __hub_publish_hostname_url_cases }}"
+      loop_control:
+        label: "{{ item.hostname }}"
+
+...


### PR DESCRIPTION
## Summary

- Add `hub_skip_existing_collections` (default `true`) so `hub_publish` queries Automation Hub before clone/build/upload and skips items whose version already exists
- Support optional per-item `namespace`, `name`, and `collection_version` fields for pre-clone skip checks without reading `galaxy.yml`
- Apply skip logic to `hub_custom_collections`, `hub_collection_list` tarball paths, and local-source dict entries; honor per-item `overwrite_existing`/`force` at upload time

Fixes #1412

## Test plan

- [x] `ansible-lint roles/hub_publish/` passes (production profile)
- [x] Manual integration test against AAP: first run publishes collection, second run skips clone/build/upload with assertions on `__hub_publish_pending_items`, `__hub_collection_list`, and `__hub_publish_should_skip`
- [ ] CI pre-commit workflow


Made with [Cursor](https://cursor.com)