### PR TITLE
Skip host deletion when inventory is also absent

### DIFF
--- a/changelogs/fragments/1421-skip-hosts-when-inventory-absent.yml
+++ b/changelogs/fragments/1421-skip-hosts-when-inventory-absent.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - controller_hosts - Skip deleting hosts when their inventory is also marked for deletion, avoiding failures from inventory cascade deletes (https://github.com/redhat-cop/infra.aap_configuration/issues/1421).
+...

--- a/roles/controller_hosts/README.md
+++ b/roles/controller_hosts/README.md
@@ -4,6 +4,12 @@
 
 An Ansible Role to add/update/remove hosts on Ansible Controller.
 
+When a host and its inventory are both marked for deletion (`state: absent`),
+this role skips deleting the host. Inventory deletion already removes member
+hosts, and attempting to delete the host afterward fails because the inventory
+no longer exists. Hosts whose inventory is not being deleted are still removed
+normally.
+
 ## Requirements
 
 ansible-galaxy collection install -r tests/collections/requirements.yml to be installed

--- a/roles/controller_hosts/tasks/main.yml
+++ b/roles/controller_hosts/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+# Deleting an inventory cascades and removes its hosts. When both are marked
+# absent, skip host deletion so the role does not fail looking up a removed inventory.
+# See: https://github.com/redhat-cop/infra.aap_configuration/issues/1421
+- name: Identify inventories marked for deletion
+  ansible.builtin.set_fact:
+    __controller_inventories_absent_names: "{{ __absent_with_state + __absent_via_platform_state }}"
+  vars:
+    __inv_list: "{{ inventory if inventory is defined else (controller_inventories | default([])) }}"
+    __absent_with_state: "{{ __inv_list | selectattr('state', 'defined') | selectattr('state', 'equalto', 'absent') | map(attribute='name') | list }}"
+    __absent_via_platform_state: "{{ (__inv_list | rejectattr('state', 'defined') | map(attribute='name') | list) if ((platform_state | default('present')) == 'absent') else [] }}"
+
 - name: Manage Controller Hosts Block
   vars:
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
@@ -26,6 +37,10 @@
         loop_var: __controller_host_item
         label: "{{ __operation.verb }} Controller host {{ __controller_host_item.name }}"
         pause: "{{ controller_configuration_hosts_loop_delay }}"
+      when:
+        - >-
+          (__controller_host_item.state | default(platform_state | default('present'))) != 'absent'
+          or __controller_host_item.inventory not in __controller_inventories_absent_names
       async: "{{ ansible_check_mode | ternary(0, 1000) }}"
       poll: 0
       register: __host_job_async
@@ -44,7 +59,7 @@
         - __host_job_async_results_item.ansible_job_id is defined
       ansible.builtin.include_role:
         name: infra.aap_configuration.collect_async_status
-      loop: "{{ __host_job_async.results }}"
+      loop: "{{ __host_job_async.results | default([]) }}"
       loop_control:
         loop_var: __host_job_async_results_item
         label: "{{ __operation.verb }} Controller Host {{ __host_job_async_results_item.__controller_host_item.name }} | Wait for finish the Hosts {{ __operation.action }}"
@@ -66,7 +81,7 @@
       ansible.builtin.async_status:
         jid: "{{ __host_job_async_results_item.ansible_job_id }}"
         mode: cleanup
-      loop: "{{ __host_job_async.results }}"
+      loop: "{{ __host_job_async.results | default([]) }}"
       loop_control:
         loop_var: __host_job_async_results_item
         label: "Cleaning up job results file: {{ __host_job_async_results_item.results_file | default('Unknown') }}"

--- a/roles/controller_hosts/tests/test_skip_on_inventory_absent.yml
+++ b/roles/controller_hosts/tests/test_skip_on_inventory_absent.yml
@@ -1,0 +1,88 @@
+---
+# Unit-style checks for host skip logic when inventories are also absent (issue 1421).
+# Does not require a live Controller; only validates the filter expressions used by the role.
+- name: Verify host skip when inventory also absent
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    platform_state: present
+    controller_inventories:
+      - name: delete-me
+        organization: Default
+        state: absent
+      - name: keep-me
+        organization: Default
+        state: present
+    controller_hosts:
+      - name: host-on-deleted-inv
+        inventory: delete-me
+        state: absent
+      - name: host-on-kept-inv
+        inventory: keep-me
+        state: absent
+      - name: host-present-on-deleted-inv
+        inventory: delete-me
+        state: present
+  tasks:
+    - name: Identify inventories marked for deletion
+      ansible.builtin.set_fact:
+        __controller_inventories_absent_names: "{{ __absent_with_state + __absent_via_platform_state }}"
+      vars:
+        __inv_list: "{{ inventory if inventory is defined else (controller_inventories | default([])) }}"
+        __absent_with_state: "{{ __inv_list | selectattr('state', 'defined') | selectattr('state', 'equalto', 'absent') | map(attribute='name') | list }}"
+        __absent_via_platform_state: "{{ (__inv_list | rejectattr('state', 'defined') | map(attribute='name') | list) if ((platform_state | default('present')) == 'absent') else [] }}"
+
+    - name: Evaluate skip condition per host
+      ansible.builtin.set_fact:
+        __should_manage: "{{ __should_manage | default({}) | combine({item.name: ((item.state | default(platform_state | default('present'))) != 'absent') or (item.inventory not in __controller_inventories_absent_names)}) }}"
+      loop: "{{ controller_hosts }}"
+
+    - name: Assert absent inventory detection
+      ansible.builtin.assert:
+        that:
+          - "'delete-me' in __controller_inventories_absent_names"
+          - "'keep-me' not in __controller_inventories_absent_names"
+          - not __should_manage['host-on-deleted-inv']
+          - __should_manage['host-on-kept-inv']
+          - __should_manage['host-present-on-deleted-inv']
+
+- name: Verify platform_state absent marks inventories without explicit state
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    platform_state: absent
+    controller_inventories:
+      - name: implied-absent
+        organization: Default
+      - name: explicitly-present
+        organization: Default
+        state: present
+    controller_hosts:
+      - name: host-implied
+        inventory: implied-absent
+      - name: host-explicit-present-inv
+        inventory: explicitly-present
+  tasks:
+    - name: Identify inventories marked for deletion
+      ansible.builtin.set_fact:
+        __controller_inventories_absent_names: "{{ __absent_with_state + __absent_via_platform_state }}"
+      vars:
+        __inv_list: "{{ inventory if inventory is defined else (controller_inventories | default([])) }}"
+        __absent_with_state: "{{ __inv_list | selectattr('state', 'defined') | selectattr('state', 'equalto', 'absent') | map(attribute='name') | list }}"
+        __absent_via_platform_state: "{{ (__inv_list | rejectattr('state', 'defined') | map(attribute='name') | list) if ((platform_state | default('present')) == 'absent') else [] }}"
+
+    - name: Evaluate skip condition per host
+      ansible.builtin.set_fact:
+        __should_manage: "{{ __should_manage | default({}) | combine({item.name: ((item.state | default(platform_state | default('present'))) != 'absent') or (item.inventory not in __controller_inventories_absent_names)}) }}"
+      loop: "{{ controller_hosts }}"
+
+    - name: Assert platform_state absent behavior
+      ansible.builtin.assert:
+        that:
+          - "'implied-absent' in __controller_inventories_absent_names"
+          - "'explicitly-present' not in __controller_inventories_absent_names"
+          - not __should_manage['host-implied']
+          - __should_manage['host-explicit-present-inv']
+...


### PR DESCRIPTION
## Summary
- Fixes #1421 by skipping host deletes when the host's inventory is also marked `absent`, since inventory deletion already cascades and removes hosts
- Documents the behavior in the `controller_hosts` README and adds a changelog fragment
- Adds a unit-style filter test that does not require a live Controller

## Test plan
- [x] `ansible-playbook roles/controller_hosts/tests/test_skip_on_inventory_absent.yml`
- [x] Pre-commit hooks (ansible-lint, changelog, markdownlint) passed on commit
- [ ] Against a live AAP: mark an inventory and its hosts `state: absent` in one run and confirm no host lookup failure; inventory is removed and hosts go with it
- [ ] Against a live AAP: mark only a host `absent` while its inventory stays `present` and confirm the host is still deleted


Made with [Cursor](https://cursor.com)