### PR TITLE
Fix workflow-level limit empty string overriding node limits

### DIFF
--- a/changelogs/fragments/fix-workflow-limit-empty-string.yml
+++ b/changelogs/fragments/fix-workflow-limit-empty-string.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - >-
+    controller_workflow_job_templates - Do not send an empty workflow-level limit when
+    ``limit`` is unset or null. Exported workflow definitions commonly use ``limit: null``,
+    which was rendered as an empty string and stored in ``char_prompts``, causing workflow
+    node limits to be ignored at runtime.
+...

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -86,7 +86,7 @@ This also speeds up the overall role.
 |`extra_vars`|""|no|dict|Specify extra_vars for the template.|
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
-|`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit|
+|`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit. Omit or set to null to leave the workflow-level limit unset so node-level limits can apply. Only set a non-empty value to override limits for all nodes.|
 |`labels`|""|no|list|The labels applied to this workflow job template. Set to `[]` to remove all labels. Omitting this key leaves existing labels unchanged. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -26,7 +26,7 @@
         organization: "{{ __workflow_loop_item.organization.name | default(__workflow_loop_item.organization | default(('' if controller_configuration_workflows_enforce_defaults else omit), true)) }}"
         ask_variables_on_launch: "{{ __workflow_loop_item.ask_variables_on_launch | default((false if controller_configuration_workflows_enforce_defaults else omit)) }}"
         inventory: "{{ __workflow_loop_item.inventory.name | default(__workflow_loop_item.inventory | default(('' if controller_configuration_workflows_enforce_defaults else omit), true)) }}"
-        limit: "{{ __workflow_loop_item.limit | default(('' if controller_configuration_workflows_enforce_defaults else omit), false) }}"
+        limit: "{{ __workflow_loop_item.limit | default(omit, true) }}"
         labels: "{{ __workflow_loop_item.labels if __workflow_loop_item.labels is defined else (__workflow_loop_item.related.labels | map(attribute='name') | list if __workflow_loop_item.related.labels is defined else ([] if controller_configuration_workflows_enforce_defaults else omit)) }}"
         scm_branch: "{{ __workflow_loop_item.scm_branch | default(('' if controller_configuration_workflows_enforce_defaults else omit), true) }}"
         ask_inventory_on_launch: "{{ __workflow_loop_item.ask_inventory_on_launch | default((false if controller_configuration_workflows_enforce_defaults else omit)) }}"


### PR DESCRIPTION
## Summary

- Fix `controller_workflow_job_templates` so unset or null workflow-level `limit` values are omitted instead of being sent as an empty string.
- Prevents AAP from storing `{"limit": ""}` in `char_prompts`, which overrides per-node limits at runtime when job templates use `ask_limit_on_launch`.
- Document the expected workflow-level `limit` behavior in the role README.

## Test plan

- [ ] Create a job template with `ask_limit_on_launch: true`
- [ ] Create two workflows via IaC sharing that job template, each with a different node-level `limit`
- [ ] Verify `char_prompts` on the workflow job template does not contain `"limit": ""` after apply
- [ ] Launch both workflows and confirm each run respects its node-level limit
- [ ] Confirm a workflow with an explicit non-empty workflow-level `limit` still overrides all nodes as expected
- [ ] Re-apply IaC against workflows previously affected by stale `char_prompts` and confirm node limits are honored


Made with [Cursor](https://cursor.com)