### PR TITLE
Fix RA example : fix decision environment name and add organization key

### DIFF
--- a/changelogs/fragments/fix-doc-example-rulebook.yml
+++ b/changelogs/fragments/fix-doc-example-rulebook.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fix the Rulebook Activation yaml definition example for organization is mandatory when state=present and DE is now called 'Hub Default Decision Environment' instead of 'Automation Hub...'
+...

--- a/roles/eda_rulebook_activations/README.md
+++ b/roles/eda_rulebook_activations/README.md
@@ -83,7 +83,8 @@ eda_rulebook_activations:
     description: Hook to listen for changes in GitHub
     project: EDA_example
     rulebook: git-hook-deploy-rules.yml
-    decision_environment: Automation Hub Default Decision Environment
+    decision_environment: Hub Default Decision Environment
+    organization: Default
     event_streams:
       - event_stream: "Example Event Stream"
         source_name: "Sample source"


### PR DESCRIPTION
Fix the Rulebook Activation yaml definition example :

- organization is mandatory when state=present
- DE is now called 'Hub Default Decision Environment' instead of 'Automation Hub...'

# What does this PR do?

Fix rulebook activation yaml definition example 

## How should this be tested?

Using the fixed yaml now works out of the box (providing dependencies are present)

## Is there a relevant Issue open for this?

n/a
