### PR TITLE
feat(role): auto-create labels for job and workflow templates

### DIFF
--- a/changelogs/fragments/1420-autocreate-labels.yml
+++ b/changelogs/fragments/1420-autocreate-labels.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Automatically create labels defined on job templates and workflow job templates when `aap_configuration_autocreate_labels` is set to `true`.
+...

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -70,7 +70,7 @@ This also speeds up the overall role.
 
 ### Auto-create Labels
 
-When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role before job templates are managed. Labels are collected from the `labels` field or `related.labels` on each job template. A label is only created when the job template defines an `organization`; templates without an organization are skipped. Duplicate name and organization pairs across job templates are deduplicated.
+When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role `autocreate_labels` task file before job templates are managed. Labels are collected from the `labels` field or `related.labels` on each job template. A label is only created when the job template defines an `organization`; templates without an organization are skipped. Duplicate name and organization pairs across job templates are deduplicated.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|

--- a/roles/controller_job_templates/README.md
+++ b/roles/controller_job_templates/README.md
@@ -68,6 +68,14 @@ This also speeds up the overall role.
 |`controller_configuration_job_templates_loop_delay`|`aap_configuration_loop_delay`|no|This sets the pause between each item in the loop for the role. To help when API is getting overloaded.|
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
+### Auto-create Labels
+
+When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role before job templates are managed. Labels are collected from the `labels` field or `related.labels` on each job template. A label is only created when the job template defines an `organization`; templates without an organization are skipped. Duplicate name and organization pairs across job templates are deduplicated.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_autocreate_labels`|`false`|no|Automatically create labels defined on job templates when an organization is set|
+
 ## Data Structure
 
 ### Job Template Variables
@@ -124,7 +132,7 @@ This also speeds up the overall role.
 |`webhook_service`|""|no|str|Service that webhook requests will be accepted from (github, gitlab)|
 |`webhook_credential`|""|no|str|Personal Access Token for posting back the status to the service API|
 |`scm_branch`|""|no|str|Branch to use in job run. Project default used if blank. Only allowed if project allow_override field is set to true.|
-|`labels`|""|no|list|The labels applied to this job template. Set to `[]` to remove all labels. Omitting this key leaves existing labels unchanged. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|list|The labels applied to this job template. Set to `[]` to remove all labels. Omitting this key leaves existing labels unchanged. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist. Labels can be automatically created if `aap_configuration_autocreate_labels` is set to `true` and organization is defined on the job template.|
 |`custom_virtualenv`|""|no|str|Local absolute file path containing a custom Python virtualenv to use.|
 |`notification_templates_started`|""|no|list|The notifications on started to use for this organization in a list. Set to `[]` to remove all. Omitting this key leaves existing notifications unchanged.|
 |`notification_templates_success`|""|no|list|The notifications on success to use for this organization in a list. Set to `[]` to remove all. Omitting this key leaves existing notifications unchanged.|

--- a/roles/controller_job_templates/defaults/main.yml
+++ b/roles/controller_job_templates/defaults/main.yml
@@ -8,4 +8,5 @@ controller_configuration_job_templates_loop_delay: "{{ aap_configuration_loop_de
 aap_configuration_async_dir:
 controller_configuration_job_templates_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true
+aap_configuration_autocreate_labels: false
 ...

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -1,4 +1,23 @@
 ---
+- name: Auto create labels for job templates
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_labels
+  when: aap_configuration_autocreate_labels
+  vars:
+    _jts: "{{ job_templates if job_templates is defined else controller_templates }}"
+    controller_labels: "{{ _controller_labels | from_yaml | default([], true) | unique | list }}"
+    _controller_labels: |
+      {% for _jt in _jts %}
+      {% set _org = _jt.organization.name | default(_jt.organization | default(none), true) %}
+      {% if _org %}
+      {% for _label in (_jt.labels | default([])) + (_jt.related.labels | default([])) %}
+      {% set _name = _label.name | default(_label) %}
+      - name: "{{ _name }}"
+        organization: "{{ _org }}"
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
+
 - name: Manage Controller Job Templates Block
   vars:
     ansible_async_dir: "{{ aap_configuration_async_dir }}"

--- a/roles/controller_job_templates/tasks/main.yml
+++ b/roles/controller_job_templates/tasks/main.yml
@@ -2,21 +2,10 @@
 - name: Auto create labels for job templates
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_labels
+    tasks_from: autocreate_labels
   when: aap_configuration_autocreate_labels
   vars:
-    _jts: "{{ job_templates if job_templates is defined else controller_templates }}"
-    controller_labels: "{{ _controller_labels | from_yaml | default([], true) | unique | list }}"
-    _controller_labels: |
-      {% for _jt in _jts %}
-      {% set _org = _jt.organization.name | default(_jt.organization | default(none), true) %}
-      {% if _org %}
-      {% for _label in (_jt.labels | default([])) + (_jt.related.labels | default([])) %}
-      {% set _name = _label.name | default(_label) %}
-      - name: "{{ _name }}"
-        organization: "{{ _org }}"
-      {% endfor %}
-      {% endif %}
-      {% endfor %}
+    controller_labels_autocreate_source: "{{ job_templates if job_templates is defined else controller_templates }}"
 
 - name: Manage Controller Job Templates Block
   vars:

--- a/roles/controller_labels/README.md
+++ b/roles/controller_labels/README.md
@@ -52,6 +52,16 @@ This also speeds up the overall role.
 |`controller_configuration_labels_loop_delay`|`aap_configuration_loop_delay`|no|This sets the pause between each item in the loop for the role. To help when API is getting overloaded.|
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
+### Auto-create Labels from Templates
+
+The `autocreate_labels` task file builds and manages labels referenced on job templates or workflow job templates. It is included by `controller_job_templates` and `controller_workflow_job_templates` when `aap_configuration_autocreate_labels` is set to `true`.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`controller_labels_autocreate_source`|`[]`|yes|List of job template or workflow job template definitions to extract labels from|
+
+Labels are collected from the `labels` and `related.labels` fields on each item in `controller_labels_autocreate_source`, and from `labels` and `related.labels` on each entry in `simplified_workflow_nodes` when present. A label is only created when the item defines an `organization`; items without an organization are skipped. Duplicate name and organization pairs are deduplicated before labels are managed.
+
 ## Data Structure
 
 ### Labels Variables

--- a/roles/controller_labels/defaults/main.yml
+++ b/roles/controller_labels/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 controller_labels: []
+controller_labels_autocreate_source: []
 controller_configuration_labels_secure_logging: "{{ aap_configuration_secure_logging | default('false') }}"
 controller_configuration_labels_async_retries: "{{ aap_configuration_async_retries | default(50) }}"
 controller_configuration_labels_async_delay: "{{ aap_configuration_async_delay | default(1) }}"

--- a/roles/controller_labels/tasks/autocreate_labels.yml
+++ b/roles/controller_labels/tasks/autocreate_labels.yml
@@ -1,0 +1,25 @@
+---
+- name: autocreate_labels | Manage auto-created controller labels
+  ansible.builtin.include_tasks: main.yml
+  when: controller_labels | length > 0
+  vars:
+    controller_labels: "{{ _controller_labels | from_yaml | default([], true) | unique | list }}"
+    _controller_labels: |
+      {% for _obj in controller_labels_autocreate_source %}
+      {% set _org = _obj.organization.name | default(_obj.organization | default(none), true) %}
+      {% if _org %}
+      {% for _label in (_obj.labels | default([])) + (_obj.related.labels | default([])) %}
+      {% set _name = _label.name | default(_label) %}
+      - name: "{{ _name }}"
+        organization: "{{ _org }}"
+      {% endfor %}
+      {% for _node in _obj.simplified_workflow_nodes | default([]) %}
+      {% for _label in (_node.labels | default([])) + (_node.related.labels | default([])) %}
+      {% set _name = _label.name | default(_label) %}
+      - name: "{{ _name }}"
+        organization: "{{ _org }}"
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
+...

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -70,7 +70,7 @@ This also speeds up the overall role.
 
 ### Auto-create Labels
 
-When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on workflow job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role before workflow job templates are managed. Labels are collected from the `labels` or `related.labels` fields on each workflow job template and on each entry in `simplified_workflow_nodes`. A label is only created when the workflow job template defines an `organization`; workflows without an organization are skipped. Duplicate name and organization pairs are deduplicated.
+When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on workflow job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role `autocreate_labels` task file before workflow job templates are managed. Labels are collected from the `labels` or `related.labels` fields on each workflow job template and on each entry in `simplified_workflow_nodes`. A label is only created when the workflow job template defines an `organization`; workflows without an organization are skipped. Duplicate name and organization pairs are deduplicated.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|

--- a/roles/controller_workflow_job_templates/README.md
+++ b/roles/controller_workflow_job_templates/README.md
@@ -68,6 +68,14 @@ This also speeds up the overall role.
 |`controller_configuration_workflow_job_templates_loop_delay`|`aap_configuration_loop_delay`|no|This sets the pause between each item in the loop for the role. To help when API is getting overloaded.|
 |`aap_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.|
 
+### Auto-create Labels
+
+When `aap_configuration_autocreate_labels` is set to `true`, labels referenced on workflow job templates are automatically created using the [controller_labels](https://github.com/redhat-cop/infra.aap_configuration/tree/devel/roles/controller_labels) role before workflow job templates are managed. Labels are collected from the `labels` or `related.labels` fields on each workflow job template and on each entry in `simplified_workflow_nodes`. A label is only created when the workflow job template defines an `organization`; workflows without an organization are skipped. Duplicate name and organization pairs are deduplicated.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`aap_configuration_autocreate_labels`|`false`|no|Automatically create labels defined on workflow job templates when an organization is set|
+
 ## Data Structure
 
 ### Variables For Workflow Job Template
@@ -87,7 +95,7 @@ This also speeds up the overall role.
 |`allow_simultaneous`|""|no|bool|Allow simultaneous runs of the workflow job template.|
 |`inventory`|""|no|str|Inventory applied as a prompt, assuming job template prompts for inventory|
 |`limit`|""|no|str|Limit applied as a prompt, assuming job template prompts for limit. Omit or set to null to leave the workflow-level limit unset so node-level limits can apply. Only set a non-empty value to override limits for all nodes.|
-|`labels`|""|no|list|The labels applied to this workflow job template. Set to `[]` to remove all labels. Omitting this key leaves existing labels unchanged. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|""|no|list|The labels applied to this workflow job template. Set to `[]` to remove all labels. Omitting this key leaves existing labels unchanged. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist. Labels can be automatically created if `aap_configuration_autocreate_labels` is set to `true` and organization is defined on the workflow job template.|
 |`ask_labels_on_launch`|""|no|bool|Prompt user for labels on launch.|
 |`job_tags`|""|no|str|Comma separated list of the tags to use for the workflow job template.|
 |`skip_tags`|""|no|str|Comma separated list of the tags to skip for the workflow job template.|
@@ -141,7 +149,7 @@ This functionality can be disabled by setting `aap_configuration_apply_object_ro
 |`forks`|Job Template default|no|str|Forks applied as a prompt. Job Template default used if not set. Only allowed if `ask_forks_on_launch` set to true on Job Template|
 |`instance_groups`|Job Template default|no|str|List of Instance Groups applied as a prompt. Job Template default used if not set. Only allowed if `ask_instance_groups_on_launch` set to true on Job Template|
 |`job_slice_count`|Job Template default|no|str|Job Slice Count to use in the job run. Job Template default used if not set. Only allowed if `ask_job_slice_count_on_launch` set to true on Job Template|
-|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist.|
+|`labels`|Job Template default|no|list|List of labels to use in the job run. Job Template default used if not set. Only allowed if `ask_labels_on_launch` set to true on Job Template. NOTE: Labels must be created with the [labels](https://github.com/redhat-cop/aap_configuration/tree/devel/roles/controller_labels) role first, an error will occur if the label supplied to this role does not exist. Labels can be automatically created if `aap_configuration_autocreate_labels` is set to `true` and organization is defined on the parent workflow job template.|
 |`timeout`|Job Template default|no|str|Timeout to use in the job run. Job Template default used if not set. Only allowed if `ask_timeout_on_launch` set to true on Job Template|
 |`approval_node`|""|no|str|A dictionary of Name, description, and timeout values for the approval node. This parameter is mutually exclusive with unified_job_template.|
 |`organization`|""|no|str|The organization of the workflow job template the node exists in. Used for looking up the workflow, not a direct model field.|

--- a/roles/controller_workflow_job_templates/defaults/main.yml
+++ b/roles/controller_workflow_job_templates/defaults/main.yml
@@ -8,4 +8,5 @@ controller_configuration_workflow_job_templates_loop_delay: "{{ aap_configuratio
 aap_configuration_async_dir:
 controller_configuration_workflows_enforce_defaults: "{{ aap_configuration_enforce_defaults | default(false) }}"
 aap_configuration_apply_object_roles: true
+aap_configuration_autocreate_labels: false
 ...

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -2,28 +2,10 @@
 - name: Auto create labels for workflow job templates
   ansible.builtin.include_role:
     name: infra.aap_configuration.controller_labels
+    tasks_from: autocreate_labels
   when: aap_configuration_autocreate_labels
   vars:
-    _workflows: "{{ controller_workflows | default(workflow_job_templates) }}"
-    controller_labels: "{{ _controller_labels | from_yaml | default([], true) | unique | list }}"
-    _controller_labels: |
-      {% for _wf in _workflows %}
-      {% set _org = _wf.organization.name | default(_wf.organization | default(none), true) %}
-      {% if _org %}
-      {% for _label in (_wf.labels | default([])) + (_wf.related.labels | default([])) %}
-      {% set _name = _label.name | default(_label) %}
-      - name: "{{ _name }}"
-        organization: "{{ _org }}"
-      {% endfor %}
-      {% for _node in _wf.simplified_workflow_nodes | default([]) %}
-      {% for _label in (_node.labels | default([])) + (_node.related.labels | default([])) %}
-      {% set _name = _label.name | default(_label) %}
-      - name: "{{ _name }}"
-        organization: "{{ _org }}"
-      {% endfor %}
-      {% endfor %}
-      {% endif %}
-      {% endfor %}
+    controller_labels_autocreate_source: "{{ controller_workflows | default(workflow_job_templates) }}"
 
 - name: Manage Controller Workflows Block
   vars:

--- a/roles/controller_workflow_job_templates/tasks/main.yml
+++ b/roles/controller_workflow_job_templates/tasks/main.yml
@@ -1,4 +1,30 @@
 ---
+- name: Auto create labels for workflow job templates
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.controller_labels
+  when: aap_configuration_autocreate_labels
+  vars:
+    _workflows: "{{ controller_workflows | default(workflow_job_templates) }}"
+    controller_labels: "{{ _controller_labels | from_yaml | default([], true) | unique | list }}"
+    _controller_labels: |
+      {% for _wf in _workflows %}
+      {% set _org = _wf.organization.name | default(_wf.organization | default(none), true) %}
+      {% if _org %}
+      {% for _label in (_wf.labels | default([])) + (_wf.related.labels | default([])) %}
+      {% set _name = _label.name | default(_label) %}
+      - name: "{{ _name }}"
+        organization: "{{ _org }}"
+      {% endfor %}
+      {% for _node in _wf.simplified_workflow_nodes | default([]) %}
+      {% for _label in (_node.labels | default([])) + (_node.related.labels | default([])) %}
+      {% set _name = _label.name | default(_label) %}
+      - name: "{{ _name }}"
+        organization: "{{ _org }}"
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
+
 - name: Manage Controller Workflows Block
   vars:
     ansible_async_dir: "{{ aap_configuration_async_dir }}"


### PR DESCRIPTION
## Summary

- Add `aap_configuration_autocreate_labels` to `controller_job_templates` and `controller_workflow_job_templates` to automatically create labels referenced on templates before they are managed.
- Labels are collected from `labels` and `related.labels` on each template. Workflow templates also collect labels from `simplified_workflow_nodes`.
- Labels are only created when the template defines an `organization`; duplicate name/organization pairs are deduplicated.

Closes #1420

## Changes

- New variable `aap_configuration_autocreate_labels` (default: `false`) in both roles
- Pre-management task includes `controller_labels` role with dynamically built `controller_labels` list
- README documentation for both roles
- Changelog fragment added

## Test plan

- [x] Verified label extraction logic with `test/autocreate_labels.yml` playbook
- [x] `ansible-lint` passes (CI)
- [x] `pre-commit` passes (CI)
- [x] Integration tests pass against live AAP instance (if applicable)


Made with [Cursor](https://cursor.com)