### PR TITLE
Add force_restart option to eda_rulebook_activations

### DIFF
--- a/changelogs/fragments/eda-rulebook-activations-force-restart.yml
+++ b/changelogs/fragments/eda-rulebook-activations-force-restart.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    eda_rulebook_activations - Add per-object ``force_restart`` option to stop a
+    running rulebook activation before applying changes and start it again afterward.
+...

--- a/roles/eda_rulebook_activations/README.md
+++ b/roles/eda_rulebook_activations/README.md
@@ -50,6 +50,10 @@ This also speeds up the overall role.
 
 ## Data Structure
 
+### ⚠️ WARNING
+
+**The `force_restart` option stops a running rulebook activation before applying configuration changes and starts it again afterward when the desired state is `present` or `enabled`. This causes a service outage and may result in missed events and alerts during the restart window. Only use `force_restart` when you understand and accept this impact.**
+
 ### Rulebook activation Variables
 
 |Variable Name|Default Value|Required|Type|Description|
@@ -71,6 +75,7 @@ This also speeds up the overall role.
 |`swap_single_source`|"true"|no|bool|Allow swapping of single sources in a rulebook without name match.|
 |`event_streams`|""|no|list|A list of dicts defining event streams for this rulebook activation. Each dict requires `event_stream` (str, the event stream name) and one of `source_name` (str) or `source_index` (int) to identify the source. `source_name` and `source_index` are mutually exclusive. See the YAML example below.|
 |`log_level`|""|no|str|Allow setting the desired log level.|
+|`force_restart`|`false`|no|bool|Stop the rulebook activation before applying changes and start it again afterward when the desired state is `enabled`, or `present` with `enabled` not set to `false`. Required when updating a running activation that cannot be modified in place. Only use on existing activations. See the warning above.|
 
 ### Standard rulebook activation Data Structure
 
@@ -92,6 +97,14 @@ eda_rulebook_activations:
       provider: github-local
       repo_url: https://github.com/ansible/ansible-rulebook.git
     enabled: false
+    state: present
+  - name: Github Hook
+    description: Hook to listen for changes in GitHub
+    project: EDA_example
+    rulebook: git-hook-deploy-rules.yml
+    decision_environment: Automation Hub Default Decision Environment
+    organization: Default
+    force_restart: true
     state: present
 ```
 

--- a/roles/eda_rulebook_activations/tasks/main.yml
+++ b/roles/eda_rulebook_activations/tasks/main.yml
@@ -5,6 +5,25 @@
     ansible_async_dir: "{{ aap_configuration_async_dir }}"
   no_log: "{{ eda_configuration_rulebook_activations_secure_logging }}"
   block:
+    - name: Stop EDA Controller rulebook activation for forced restart
+      ansible.eda.rulebook_activation:
+        name: "{{ __ra_stop_item.name }}"
+        organization: "{{ __ra_stop_item.organization | default(omit) }}"
+        state: disabled
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_token: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(10, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ eda_rulebook_activations }}"
+      loop_control:
+        loop_var: __ra_stop_item
+        label: "Stop rulebook activation {{ __ra_stop_item.name }} before forced restart"
+      when:
+        - __ra_stop_item.force_restart | default(false) | bool
+        - (__ra_stop_item.state | default(platform_state | default('present'))) not in ['absent']
+
     - name: Add EDA Controller rulebook activation
       ansible.eda.rulebook_activation:
         name: "{{ __ra_item.name }}"
@@ -61,6 +80,27 @@
         cas_error_list_var_name: "eda_rulebook_activations_errors"
         __operation: "{{ operation_translate[__rulebook_activations_job_async_result_item.__ra_item.state | default(platform_state) | default('present')] }}"
         cas_object_label: "{{ __operation.verb }} rulebook activation {{ __rulebook_activations_job_async_result_item.__ra_item.name }} | Wait for finish the rulebook activation {{ __operation.action }}"
+
+    - name: Start EDA Controller rulebook activation after forced restart
+      ansible.eda.rulebook_activation:
+        name: "{{ __ra_start_item.name }}"
+        organization: "{{ __ra_start_item.organization | default(omit) }}"
+        state: enabled
+        controller_host: "{{ aap_hostname | default(omit, true) }}"
+        controller_username: "{{ aap_username | default(omit, true) }}"
+        controller_password: "{{ aap_password | default(omit, true) }}"
+        controller_token: "{{ aap_token | default(omit, true) }}"
+        request_timeout: "{{ aap_request_timeout | default(10, true) }}"
+        validate_certs: "{{ aap_validate_certs | default(omit) }}"
+      loop: "{{ eda_rulebook_activations }}"
+      loop_control:
+        loop_var: __ra_start_item
+        label: "Start rulebook activation {{ __ra_start_item.name }} after forced restart"
+      when:
+        - __ra_start_item.force_restart | default(false) | bool
+        - (__ra_start_item.state | default(platform_state | default('present'))) == 'enabled' or
+          ((__ra_start_item.state | default(platform_state | default('present'))) == 'present' and
+          (__ra_start_item.enabled | default(true) | bool))
 
   always:
     - name: Cleanup async results files


### PR DESCRIPTION
## Summary

- Adds a per-object `force_restart` option to `eda_rulebook_activations` to stop a running rulebook activation before applying changes and start it again afterward
- Automates the manual stop/update/start workflow described in #1443
- Documents the outage and missed-events risk with a prominent warning in the role README

## Test plan

- [ ] Run the role against an existing running rulebook activation with `force_restart: true` and confirm the activation is disabled, updated, and re-enabled
- [ ] Run the role with `force_restart: false` (default) and confirm existing behavior is unchanged
- [ ] Verify `force_restart: true` with `state: disabled` or `enabled: false` stops for update but does not restart
- [ ] Confirm pre-commit passes (`ansible-lint`, `markdownlint-cli2`, changelog validation)

Closes #1443


Made with [Cursor](https://cursor.com)